### PR TITLE
Feature/logging to file

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -3,6 +3,7 @@ import { renameAllFiles } from "./scripts/renameAllFiles";
 import { getFileCount } from "./scripts/getFileCount";
 import { input, confirm } from "@inquirer/prompts";
 import { logToFile } from "./scripts/logToFile";
+import { setChosenPath } from "./scripts/globals";
 
 const chooseDirectory = async (): Promise<string> =>
   await input({
@@ -20,6 +21,8 @@ const askConfirmation = async (): Promise<boolean> =>
 const main = async (): Promise<void> => {
   try {
     const directory = await chooseDirectory();
+    setChosenPath(directory);
+
     const fileCount = await getFileCount(directory);
 
     if (fileCount > 0) {

--- a/index.ts
+++ b/index.ts
@@ -2,8 +2,7 @@ import { existsSync, lstatSync } from "fs";
 import { renameAllFiles } from "./scripts/renameAllFiles";
 import { getFileCount } from "./scripts/getFileCount";
 import { input, confirm } from "@inquirer/prompts";
-import { logToFile } from "./scripts/logToFile";
-import { setChosenPath } from "./scripts/globals";
+import { logToFile, setChosenPath } from "./scripts/logToFile";
 
 const chooseDirectory = async (): Promise<string> =>
   await input({

--- a/index.ts
+++ b/index.ts
@@ -2,6 +2,7 @@ import { existsSync, lstatSync } from "fs";
 import { renameAllFiles } from "./scripts/renameAllFiles";
 import { getFileCount } from "./scripts/getFileCount";
 import { input, confirm } from "@inquirer/prompts";
+import { logToFile } from "./scripts/logToFile";
 
 const chooseDirectory = async (): Promise<string> =>
   await input({
@@ -29,27 +30,34 @@ const main = async (): Promise<void> => {
       const confirm = await askConfirmation();
 
       if (confirm) {
-        console.log("Scanning...");
+        logToFile(
+          `Renaming all the JPG and Nikon RAW files in ${directory}`,
+          {}
+        );
+        logToFile("Scanning...", { logToConsole: true });
 
         const fileCountByType = await renameAllFiles(directory, fileCount);
         const { raw, jpg, skipped } = fileCountByType;
 
-        console.log(`Scanned ${raw + jpg + skipped} files in total.`);
-        console.log("RAW files renamed: ", raw);
-        console.log("JPG files renamed: ", jpg);
-        console.log("Files skipped: ", skipped);
+        logToFile(`Scanned ${raw + jpg + skipped} files in total.`, {
+          logToConsole: true,
+        });
+        logToFile(`RAW files renamed: ${raw}`, { logToConsole: true });
+        logToFile(`JPG files renamed: ${jpg}`, { logToConsole: true });
+        logToFile(`Files skipped: ${skipped}`, { logToConsole: true });
       }
     } else {
-      console.log(
-        "There are no files in the given directory. Exiting the program."
+      logToFile(
+        "There are no files in the given directory. Exiting the program.",
+        { logToConsole: true }
       );
     }
 
     process.exit(0);
   } catch (error) {
-    console.error(
+    logToFile(
       "Error occurred when running the main segment of the application:",
-      error
+      { error, logToConsole: true }
     );
     process.exit(1);
   }

--- a/scripts/getFileCount.ts
+++ b/scripts/getFileCount.ts
@@ -1,5 +1,6 @@
 import { join } from "path";
 import { readdir } from "fs/promises";
+import { logToFile } from "./logToFile";
 
 export const getFileCount = async (directory: string): Promise<number> => {
   let fileCount = 0;
@@ -16,7 +17,10 @@ export const getFileCount = async (directory: string): Promise<number> => {
       }
     }
   } catch (error) {
-    console.error("Error occured when trying to count files:", error);
+    logToFile("Error occured when trying to count files", {
+      error,
+      logToConsole: true,
+    });
     process.exit(0);
   }
 

--- a/scripts/getMetadata.ts
+++ b/scripts/getMetadata.ts
@@ -1,4 +1,5 @@
 import { EXIFTags, exiftool } from "exiftool-vendored";
+import { logToFile } from "./logToFile";
 
 interface DateTime {
   year: number;
@@ -60,10 +61,6 @@ export const getMetadata = async (
       iso: metadata.ISO,
     };
   } catch (error) {
-    if (error instanceof Error) {
-      console.error("\nError while extracting metadata.", error.message);
-    } else {
-      console.error("\nAn unknown error occurred.");
-    }
+    logToFile("Error while extracting metadata", { error });
   }
 };

--- a/scripts/getNewFilename.ts
+++ b/scripts/getNewFilename.ts
@@ -1,4 +1,5 @@
 import { Metadata } from "./getMetadata";
+import { logToFile } from "./logToFile";
 
 // Ensure the number is always 2-digit e.g. 02 instead of 2
 const padded = (time: number) => time.toString().padStart(2, "0");
@@ -22,11 +23,7 @@ export const getNewFilename = (
 
     return segments.join("_") + extension;
   } catch (error) {
-    if (error instanceof Error) {
-      console.error("Error occured when building new filename.", error.message);
-    } else {
-      console.error("An unknown error occurred.");
-    }
+    logToFile("Error occured when building new filename", { error });
 
     return null;
   }

--- a/scripts/globals.ts
+++ b/scripts/globals.ts
@@ -1,0 +1,7 @@
+let CHOSEN_PATH: string = process.cwd();
+
+export const getChosenPath = () => CHOSEN_PATH;
+
+export const setChosenPath = (newPath: string) => {
+  CHOSEN_PATH = newPath;
+};

--- a/scripts/globals.ts
+++ b/scripts/globals.ts
@@ -1,7 +1,0 @@
-let CHOSEN_PATH: string = process.cwd();
-
-export const getChosenPath = () => CHOSEN_PATH;
-
-export const setChosenPath = (newPath: string) => {
-  CHOSEN_PATH = newPath;
-};

--- a/scripts/logToFile.ts
+++ b/scripts/logToFile.ts
@@ -1,7 +1,6 @@
 import { join } from "path";
 import { appendFileSync } from "fs";
-
-const logFilePath = join(process.cwd(), "change.log");
+import { getChosenPath } from "./globals";
 
 export const logToFile = (
   message: string,
@@ -11,6 +10,7 @@ export const logToFile = (
   const errorMessage =
     error && error instanceof Error ? `: ${error.message}` : "";
 
+  const logFilePath = join(getChosenPath(), "change.log");
   appendFileSync(logFilePath, `${timestamp} - ${message}${errorMessage}\n`);
 
   if (logToConsole && error) {

--- a/scripts/logToFile.ts
+++ b/scripts/logToFile.ts
@@ -1,0 +1,25 @@
+import { join } from "path";
+import { appendFileSync } from "fs";
+
+const logFilePath = join(process.cwd(), "change.log");
+
+export const logToFile = (
+  message: string,
+  { error, logToConsole }: { error?: unknown; logToConsole?: boolean }
+): void => {
+  const timestamp = new Date().toISOString();
+  const errorMessage =
+    error && error instanceof Error ? `: ${error.message}` : "";
+
+  appendFileSync(logFilePath, `${timestamp} - ${message}${errorMessage}\n`);
+
+  if (logToConsole && error) {
+    console.error(message, error instanceof Error ? error.message : error);
+
+    return;
+  }
+
+  if (logToConsole) {
+    console.log(message);
+  }
+};

--- a/scripts/logToFile.ts
+++ b/scripts/logToFile.ts
@@ -1,6 +1,13 @@
 import { join } from "path";
 import { appendFileSync } from "fs";
-import { getChosenPath } from "./globals";
+
+let CHOSEN_PATH: string = process.cwd();
+
+const getChosenPath = () => CHOSEN_PATH;
+
+export const setChosenPath = (newPath: string) => {
+  CHOSEN_PATH = newPath;
+};
 
 const getLogFilename = (): string => {
   const now = new Date();

--- a/scripts/logToFile.ts
+++ b/scripts/logToFile.ts
@@ -2,6 +2,22 @@ import { join } from "path";
 import { appendFileSync } from "fs";
 import { getChosenPath } from "./globals";
 
+const getLogFilename = (): string => {
+  const now = new Date();
+  const pad = (n: number) => String(n).padStart(2, "0");
+
+  const date = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(
+    now.getDate()
+  )}`;
+  const time = `${pad(now.getHours())}-${pad(now.getMinutes())}-${pad(
+    now.getSeconds()
+  )}`;
+
+  return `renamer_${date}_${time}.log`;
+};
+
+const LOG_FILENAME = getLogFilename();
+
 export const logToFile = (
   message: string,
   { error, logToConsole }: { error?: unknown; logToConsole?: boolean }
@@ -10,7 +26,7 @@ export const logToFile = (
   const errorMessage =
     error && error instanceof Error ? `: ${error.message}` : "";
 
-  const logFilePath = join(getChosenPath(), "change.log");
+  const logFilePath = join(getChosenPath(), LOG_FILENAME);
   appendFileSync(logFilePath, `${timestamp} - ${message}${errorMessage}\n`);
 
   if (logToConsole && error) {

--- a/scripts/processFile.ts
+++ b/scripts/processFile.ts
@@ -3,6 +3,7 @@ import { rename } from "fs/promises";
 import { getMetadata } from "./getMetadata";
 import { getNewFilename } from "./getNewFilename";
 import { Dirent } from "fs";
+import { logToFile } from "./logToFile";
 
 const isJpg = (fileName: string): boolean =>
   extname(fileName).toLowerCase() === ".jpg";
@@ -13,9 +14,11 @@ const isRaw = (fileName: string): boolean =>
 const renameFile = async (oldPath: string, newPath: string): Promise<void> => {
   try {
     await rename(oldPath, newPath);
-    console.log(`\nRenamed ${basename(oldPath)} to ${basename(newPath)}`);
+    logToFile(`Renamed ${basename(oldPath)} to ${basename(newPath)}`, {});
   } catch (error) {
-    console.error(`\nError occurred when renaming the file ${oldPath}.`, error);
+    logToFile(`Error occurred when renaming the file ${oldPath}`, {
+      error,
+    });
   }
 };
 
@@ -34,7 +37,7 @@ export const processFile = async (entry: Dirent): Promise<ProcessedFile> => {
   const metadata = await getMetadata(path);
 
   if (metadata === undefined) {
-    console.error(`Couldn't retrieve metadata for ${name}`);
+    logToFile(`Couldn't retrieve metadata for ${name}`, {});
 
     return "SKIPPED";
   }
@@ -46,6 +49,8 @@ export const processFile = async (entry: Dirent): Promise<ProcessedFile> => {
   }
 
   if (name === newFilename) {
+    logToFile(`Skipping ${name} since it's already renamed`, {});
+
     return "SKIPPED";
   }
 


### PR DESCRIPTION
To keep the progress bar nice and clean, put all the logs into the file stored within the target folder instead of showing them in terminal.